### PR TITLE
Minor HomePage Bug Fixes

### DIFF
--- a/frontend/src/components/BookThumbnail.less
+++ b/frontend/src/components/BookThumbnail.less
@@ -36,11 +36,11 @@
 }
 
 .bookstore-book-thumbnail-title:hover {
-  transform: ~"translateX(min(@{bookstore-book-thumbnail-size} - 32px - 100%, 0px))";
+  transform: ~"translateX(min(@{bookstore-book-thumbnail-size} - 32px - 100%, 1px - 1px))";
 }
 
 .bookstore-book-thumbnail-title-lg:hover {
-  transform: ~"translateX(min(@{bookstore-book-thumbnail-size-lg} - 64px - 100%, 0px))";
+  transform: ~"translateX(min(@{bookstore-book-thumbnail-size-lg} - 64px - 100%, 1px - 1px))";
 }
 
 .bookstore-book-thumbnail-author {
@@ -53,11 +53,11 @@
 }
 
 .bookstore-book-thumbnail-author:hover {
-  transform: ~"translateX(min(@{bookstore-book-thumbnail-size} - 32px - 100%, 0px))";
+  transform: ~"translateX(min(@{bookstore-book-thumbnail-size} - 32px - 100%, 1px - 1px))";
 }
 
 .bookstore-book-thumbnail-author-lg:hover {
-  transform: ~"translateX(min(@{bookstore-book-thumbnail-size-lg} - 64px - 100%, 0px))";
+  transform: ~"translateX(min(@{bookstore-book-thumbnail-size-lg} - 64px - 100%, 1px - 1px))";
 }
 
 .bookstore-book-thumbnail > .ant-card-body {

--- a/frontend/src/components/Section.js
+++ b/frontend/src/components/Section.js
@@ -35,9 +35,9 @@ function Section(props) {
   const { title, children } = props;
 
   return (
-    <Row className='bookstore-hp-section'>
+    <Row className='bookstore-section'>
       <Col span={24}>
-        <Title className='bookstore-hp-section-title' level={2}>
+        <Title className='bookstore-section-title' level={2}>
           {title}
         </Title>
         {children}

--- a/frontend/src/components/Section.less
+++ b/frontend/src/components/Section.less
@@ -1,9 +1,12 @@
-.bookstore-hp-section {
-  padding: 32px;
-  padding-bottom: 0px;
+.bookstore-section {
+  margin-top: 32px;
 }
 
-.bookstore-hp-section-title {
+.bookstore-section:first-of-type {
+  margin-top: 0px;
+}
+
+.bookstore-section-title {
   font-weight: 900 !important;
   margin-bottom: 0px !important;
 }

--- a/frontend/src/components/Slider.js
+++ b/frontend/src/components/Slider.js
@@ -1,6 +1,6 @@
 import './Slider.less';
 
-import React from 'react';
+import React, { useRef, useLayoutEffect } from 'react';
 
 /**
  * A horizontal sliding component.
@@ -19,6 +19,16 @@ import React from 'react';
 function Slider(props) {
   const { spaceBetween, primary } = props;
   let { children, className, style } = props;
+
+  const slider = useRef(null);
+  const scrollbarCover = useRef(null);
+
+  useLayoutEffect(() => {
+    if (!primary && scrollbarCover.current && slider.current &&
+        slider.current.scrollWidth <= slider.current.offsetWidth) {
+      scrollbarCover.current.classList.add('disabled');
+    }
+  }, [primary]);
 
   if (!primary) {
     children = children.map((child, index) =>
@@ -42,6 +52,7 @@ function Slider(props) {
           (primary ? 'bookstore-slider-primary ' : 'bookstore-slider ') +
           (className ? className : '')
         }
+        ref={slider}
         style={style}>
         {primary && children[0]
           ? [
@@ -67,7 +78,7 @@ function Slider(props) {
             ]
           : children}
       </div>
-      {!primary && <div className='bookstore-slider-scrollbar-cover' />}
+      {!primary && <div ref={scrollbarCover} className='bookstore-slider-scrollbar-cover' />}
     </div>
   );
 }

--- a/frontend/src/components/Slider.js
+++ b/frontend/src/components/Slider.js
@@ -24,8 +24,12 @@ function Slider(props) {
   const scrollbarCover = useRef(null);
 
   useLayoutEffect(() => {
-    if (!primary && scrollbarCover.current && slider.current &&
-        slider.current.scrollWidth <= slider.current.offsetWidth) {
+    if (
+      !primary &&
+      scrollbarCover.current &&
+      slider.current &&
+      slider.current.scrollWidth <= slider.current.offsetWidth
+    ) {
       scrollbarCover.current.classList.add('disabled');
     }
   }, [primary]);
@@ -78,7 +82,12 @@ function Slider(props) {
             ]
           : children}
       </div>
-      {!primary && <div ref={scrollbarCover} className='bookstore-slider-scrollbar-cover' />}
+      {!primary && (
+        <div
+          ref={scrollbarCover}
+          className='bookstore-slider-scrollbar-cover'
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Slider.js
+++ b/frontend/src/components/Slider.js
@@ -20,18 +20,20 @@ function Slider(props) {
   const { spaceBetween, primary } = props;
   let { children, className, style } = props;
 
-  children = children.map((child, index) =>
-    React.cloneElement(child, {
-      key: index,
-      className:
-        (child.props.className ? child.props.className : '') +
-        ' bookstore-slider-item',
-      style: {
-        ...child.props.style,
-        margin: '0px ' + spaceBetween / 2 + 'px',
-      },
-    })
-  );
+  if (!primary) {
+    children = children.map((child, index) =>
+      React.cloneElement(child, {
+        key: index,
+        className:
+          (child.props.className ? child.props.className : '') +
+          ' bookstore-slider-item',
+        style: {
+          ...child.props.style,
+          margin: '0px ' + spaceBetween / 2 + 'px',
+        },
+      })
+    );
+  }
 
   return (
     <div className='bookstore-slider-wrapper'>

--- a/frontend/src/components/Slider.less
+++ b/frontend/src/components/Slider.less
@@ -53,6 +53,7 @@
   background: white;
   opacity: 1;
   transition: opacity 0.2s linear;
+  pointer-events: none;
 }
 
 .bookstore-slider-wrapper:hover > .bookstore-slider-scrollbar-cover {

--- a/frontend/src/components/Slider.less
+++ b/frontend/src/components/Slider.less
@@ -12,6 +12,7 @@
   scrollbar-width: none;
   -ms-overflow-style: none;
   white-space: nowrap;
+  text-align: center;
 }
 
 .bookstore-slider-primary {
@@ -58,6 +59,10 @@
 
 .bookstore-slider-wrapper:hover > .bookstore-slider-scrollbar-cover {
   opacity: 0;
+}
+
+.bookstore-slider-scrollbar-cover.disabled {
+  opacity: 1 !important;
 }
 
 .bookstore-slider-item {

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -16,7 +16,7 @@ const { Title } = Typography;
 function HomePage(props) {
   return (
     <Row>
-      <Col  className='bookstore-hp-col' span={24}>
+      <Col className='bookstore-hp-col' span={24}>
         <div key='hp-grid' className='bookstore-hp-grid-container'>
           <div className='bookstore-hp-grid one'>
             <Title className='bookstore-welcome-text'>Welcome, Alex.</Title>
@@ -45,7 +45,11 @@ function HomePage(props) {
           </div>
           <div className='bookstore-hp-grid four'>
             <span />
-            <Skeleton title={false} paragraph={{ rows: 1, width: ['66%'] }} round />
+            <Skeleton
+              title={false}
+              paragraph={{ rows: 1, width: ['66%'] }}
+              round
+            />
           </div>
         </div>
         <Section key='hp-section-1' title={sections[0]}>

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -2,7 +2,7 @@ import './HomePage.less';
 
 import React from 'react';
 
-import { Skeleton, Typography } from 'antd';
+import { Col, Row, Skeleton, Typography } from 'antd';
 
 import BookThumbnail from '../components/BookThumbnail.js';
 import Section, { sections } from '../components/Section.js';
@@ -14,60 +14,64 @@ const { Title } = Typography;
  * The home page of the Bookstore Application.
  */
 function HomePage(props) {
-  return [
-    <div key='hp-grid' className='bookstore-hp-grid-container'>
-      <div className='bookstore-hp-grid one'>
-        <Title className='bookstore-welcome-text'>Welcome, Alex.</Title>
-        <Skeleton
-          title={false}
-          paragraph={{ rows: 2, width: ['33%', '100%'] }}
-          round
-        />
-      </div>
-      <div className='bookstore-hp-grid two'>
-        <Skeleton.Avatar size='large' />
-        <Skeleton
-          title={false}
-          paragraph={{ rows: 3, width: ['33%', '100%', '75%'] }}
-          round
-        />
-      </div>
-      <div className='bookstore-hp-grid three'>
-        <span />
-        <Skeleton
-          title={false}
-          paragraph={{ rows: 2, width: ['50%', '100%'] }}
-          round
-          avatar
-        />
-      </div>
-      <div className='bookstore-hp-grid four'>
-        <span />
-        <Skeleton title={false} paragraph={{ rows: 1, width: ['66%'] }} round />
-      </div>
-    </div>,
-    <Section key='hp-section-1' title={sections[0]}>
-      <Slider itemWidth={216} spaceBetween={16} primary>
-        {Array.from({ length: 16 }, (e, i) => (
-          <BookThumbnail key={i} />
-        ))}
-      </Slider>
-    </Section>,
-    <Section key='hp-section-2' title={sections[2]}>
-      <Slider itemWidth={216} spaceBetween={16}>
-        {Array.from({ length: 16 }, (e, i) => (
-          <BookThumbnail key={i} />
-        ))}
-      </Slider>
-    </Section>,
-    <Section key='hp-section-3' title={sections[1]}>
-      <Slider itemWidth={216} spaceBetween={16}>
-        {Array.from({ length: 16 }, (e, i) => (
-          <BookThumbnail key={i} />
-        ))}
-      </Slider>
-    </Section>,
-  ];
+  return (
+    <Row>
+      <Col  className='bookstore-hp-col' span={24}>
+        <div key='hp-grid' className='bookstore-hp-grid-container'>
+          <div className='bookstore-hp-grid one'>
+            <Title className='bookstore-welcome-text'>Welcome, Alex.</Title>
+            <Skeleton
+              title={false}
+              paragraph={{ rows: 2, width: ['33%', '100%'] }}
+              round
+            />
+          </div>
+          <div className='bookstore-hp-grid two'>
+            <Skeleton.Avatar size='large' />
+            <Skeleton
+              title={false}
+              paragraph={{ rows: 3, width: ['33%', '100%', '75%'] }}
+              round
+            />
+          </div>
+          <div className='bookstore-hp-grid three'>
+            <span />
+            <Skeleton
+              title={false}
+              paragraph={{ rows: 2, width: ['50%', '100%'] }}
+              round
+              avatar
+            />
+          </div>
+          <div className='bookstore-hp-grid four'>
+            <span />
+            <Skeleton title={false} paragraph={{ rows: 1, width: ['66%'] }} round />
+          </div>
+        </div>
+        <Section key='hp-section-1' title={sections[0]}>
+          <Slider itemWidth={216} spaceBetween={16} primary>
+            {Array.from({ length: 16 }, (e, i) => (
+              <BookThumbnail key={i} />
+            ))}
+          </Slider>
+        </Section>
+        <Section key='hp-section-2' title={sections[2]}>
+          <Slider itemWidth={216} spaceBetween={16}>
+            {Array.from({ length: 16 }, (e, i) => (
+              <BookThumbnail key={i} />
+            ))}
+          </Slider>
+        </Section>
+        <Section key='hp-section-3' title={sections[1]}>
+          <Slider itemWidth={216} spaceBetween={16}>
+            {Array.from({ length: 16 }, (e, i) => (
+              <BookThumbnail key={i} />
+            ))}
+          </Slider>
+        </Section>
+      </Col>
+    </Row>
+  );
 }
 
 export default HomePage;

--- a/frontend/src/pages/HomePage.less
+++ b/frontend/src/pages/HomePage.less
@@ -1,5 +1,9 @@
 @import "~antd/lib/style/themes/default.less";
 
+.bookstore-hp-col {
+  padding: 32px;
+}
+
 .bookstore-welcome-text {
   margin: 0px !important;
   font-weight: bold !important;
@@ -7,20 +11,17 @@
 }
 
 .bookstore-hp-grid-container {
-  padding: 32px;
   display: grid;
   grid-gap: 32px 32px;
   width: 100%;
   height: 800px;
-  padding: 24px;
   grid-template-columns: auto auto auto auto auto auto auto auto;
   grid-template-rows: auto auto auto auto auto auto;
 }
 
 .bookstore-hp-grid {
-  background: #f0f0f0;
   border-radius: 12px;
-  padding: 24px;
+  padding: 32px;
   box-shadow: @card-shadow;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
There's an unfortunate issue were the CSS/LESS Minifier used by Create React App strips the unit value from any zeros (`0px` -> `0`). Normally this is not an issue, but if you use zero inside a CSS `min()` or `calc()` it needs to retain its units or the field will be invalidated.

It doesn't seem possible to tell Create React App to not minify that section of code without ejecting the whole project, which feels like a lot for this tiny issue. Changing `0px` to `1px - 1px` should solve the issue though.

--

ALSO, bundling another tiny fix to allow the custom pink scrollbars to be clicked/dragged. Previously they could not be interacted with because of an overlapping div.

--

ALSO, increased the left margin for the large BookThumbnail component within the `primary` slider so that its shadow is not clipped.